### PR TITLE
Extract audio provider and shared hooks; add project improvement plan

### DIFF
--- a/PROJECT_IMPROVEMENT_PLAN.md
+++ b/PROJECT_IMPROVEMENT_PLAN.md
@@ -1,0 +1,135 @@
+# План улучшения проекта BhajanApp
+
+## 1) Ключевые технические риски прямо сейчас
+
+1. **Монолитный фронтенд-файл**: `pages/index.tsx` содержит и роутинг, и бизнес-логику, и UI-компоненты, и утилиты. Это сильно усложняет тестирование и развитие.  
+2. **Смешение роутинговых подходов**: в Next.js используется `react-router-dom` внутри `pages/index.tsx`, что приводит к двойному роутингу и лишней сложности для SSR/SEO.  
+3. **Невалидированная/хрупкая AI-интеграция**: в разных API используются разные модели (`gemini-1.5-pro-latest` и `gemini-pro`), есть `JSON.parse` без устойчивого ретрая/санитайза, а админский endpoint может выполнять долгие фоновые задачи в request lifecycle.  
+4. **Словарь загружается целиком**: `/api/dictionary` возвращает весь словарь, а клиент кэширует его целиком в IndexedDB — это плохо масштабируется по памяти/времени при росте данных.  
+5. **Схема БД минималистична**: таблица `Word` не содержит нормализации, версии перевода, источника/метаданных AI, индексов для типовых фильтров/поиска.
+
+## 2) Предлагаемая целевая архитектура (поэтапно)
+
+### Этап A — Разделение фронтенда и упрощение роутинга
+
+- Перейти с `react-router-dom` на нативный Next routing (`pages` или лучше `app` router при миграции).
+- Разбить `pages/index.tsx` на доменные модули:
+  - `features/bhajans/*` (list, detail, filters)
+  - `features/audio/*`
+  - `features/dictionary/*`
+  - `shared/ui/*`, `shared/lib/*`
+- Вынести кастомные хуки (`useFavorites`, `useTheme`, `useShareBhajan`, `useAudio`) в отдельные файлы с unit-тестами.
+
+**Ожидаемый эффект**: быстрее онбординг, ниже риск регрессий, проще код-ревью и рефакторинг.
+
+### Этап B — Укрепление backend/API слоя
+
+- Ввести слой `services` между API handlers и внешними зависимостями:
+  - `services/dictionary.service.ts`
+  - `services/translation.service.ts`
+  - `services/bhajan.service.ts`
+- Для AI-ответов: строгий парсинг + retry policy + fallback model.
+- Для admin задачи обновления словаря — вынести в **очередь задач** (например, BullMQ + Redis) вместо long-running запроса.
+- Добавить rate limiting и idempotency key на чувствительные endpoints.
+
+**Ожидаемый эффект**: стабильность API, предсказуемая нагрузка, меньше 500 ошибок.
+
+### Этап C — Оптимизация работы словаря
+
+- Перейти от “полного словаря” к **инкрементальному sync**:
+  - Endpoint `/api/dictionary/changes?since=<cursor>`
+  - На клиенте хранить `lastSyncAt` + применять патчи (upsert/delete).
+- Добавить серверный endpoint пакетного запроса: `/api/dictionary/lookup` для N слов сразу.
+- В IndexedDB хранить слова построчно (`keyPath: sourceText`) вместо одного объекта `full_dictionary`.
+
+**Ожидаемый эффект**: кратно меньше трафик/память, быстрый офлайн-кеш даже при росте словаря.
+
+### Этап D — Реструктуризация БД (Prisma/PostgreSQL)
+
+Предлагаемая эволюция `Word`:
+
+- Нормализовать поля:
+  - `normalizedText` (lowercase + strip punctuation), индексируемое.
+  - `language`, `confidence`, `isProperNoun` — с индексами.
+- Добавить аудит/версионирование AI:
+  - `modelName`, `promptVersion`, `rawResponse`, `translatedAt`.
+- Добавить таблицу `WordVariant` (варианты написания), связь 1-N с `Word`.
+- Добавить уникальность по `(normalizedText, sourceLanguage)` вместо только `sourceText`.
+
+**Ожидаемый эффект**: меньше дублей, лучше quality control переводов, масштабируемость аналитики.
+
+## 3) Улучшение UX и сценариев
+
+- Дебаунс поиска (300–400ms) + отмена предыдущих запросов.
+- Виртуализация длинных списков бхаджанов (react-virtual).
+- Явная индикация состояния офлайн-словаря: "актуален / нужна синхронизация".
+- Для карточки бхаджана: optimistic UI для избранного.
+- В аудиоплеере: сохранение позиции воспроизведения по `trackId`.
+
+## 4) Качество, наблюдаемость, DevEx
+
+- Добавить:
+  - ESLint + Prettier + import ordering.
+  - Unit tests (vitest/jest) для утилит (transpose, parser, cleaners).
+  - API integration tests (supertest).
+- Observability:
+  - структурированные логи (pino)
+  - trace-id в каждом запросе
+  - Sentry для FE/BE
+- CI/CD:
+  - `npm run lint`, `npm run typecheck`, `npm run test`, `prisma migrate diff` в CI.
+
+## 5) Приоритетный roadmap (прагматичный)
+
+### Sprint 1 (быстрые победы)
+- Разнести `pages/index.tsx` на модули без смены функционала.
+- Дебаунс/отмена поиска.
+- Строгая обработка ошибок AI и единая модель/конфиг.
+
+### Sprint 2
+- Инкрементальный словарь + новый формат IndexedDB.
+- Batch lookup endpoint.
+
+### Sprint 3
+- Очередь задач для `update-dictionary`.
+- Миграции БД для `Word` + индексы + аудит полей.
+
+## 6) Минимальные изменения схемы БД (пример)
+
+```prisma
+model Word {
+  id                 String   @id @default(cuid())
+  sourceText         String
+  normalizedText     String
+  sourceLanguage     String
+  transliteration    String
+  russianTranslation String
+  englishTranslation String
+  spiritualMeaning   String?
+  isProperNoun       Boolean  @default(false)
+  confidence         String
+  modelName          String?
+  promptVersion      String?
+  rawResponse        Json?
+  translatedAt       DateTime?
+  createdAt          DateTime @default(now())
+
+  @@unique([normalizedText, sourceLanguage])
+  @@index([sourceLanguage])
+  @@index([confidence])
+}
+```
+
+> Это не нужно внедрять сразу: лучше через последовательные миграции с backfill-скриптом.
+
+## 7) Что сделать первым делом (конкретно)
+
+1. Создать `features/` структуру и перенести туда хуки/компоненты из `pages/index.tsx`.
+2. Для словаря заменить хранение `full_dictionary` на объект-стор по `sourceText`.
+3. Добавить endpoint инкрементальной синхронизации и cursor-based fetch.
+4. Вынести генерацию переводов в job-queue worker.
+5. После этого — миграции `Word` и индексы.
+
+---
+
+Если нужно, следующим шагом могу подготовить **технический RFC с целевой структурой папок и пошаговым планом миграции без остановки продакшена**.

--- a/features/audio/audio-context.tsx
+++ b/features/audio/audio-context.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+type Track = { id: string; title: string; author: string; audioUrl: string };
+
+type AudioContextValue = {
+  currentTrack: Track | null;
+  isPlaying: boolean;
+  currentTime: number;
+  duration: number;
+  playbackRate: number;
+  play: (track: Track) => Promise<void>;
+  pause: () => void;
+  seek: (time: number) => void;
+  setPlaybackRate: (rate: number) => void;
+};
+
+const AudioContext = createContext<AudioContextValue | null>(null);
+
+export function AudioProvider({ children }: { children: React.ReactNode }) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [currentTrack, setCurrentTrack] = useState<Track | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [duration, setDuration] = useState(0);
+  const [playbackRate, setPlaybackRate] = useState(1);
+
+  useEffect(() => {
+    const audio = audioRef.current;
+    if (!audio) return;
+
+    const updateTime = () => setCurrentTime(audio.currentTime);
+    const updateDuration = () => setDuration(audio.duration);
+    const handleEnded = () => setIsPlaying(false);
+
+    audio.addEventListener('timeupdate', updateTime);
+    audio.addEventListener('loadedmetadata', updateDuration);
+    audio.addEventListener('ended', handleEnded);
+
+    return () => {
+      audio.removeEventListener('timeupdate', updateTime);
+      audio.removeEventListener('loadedmetadata', updateDuration);
+      audio.removeEventListener('ended', handleEnded);
+    };
+  }, [currentTrack]);
+
+  const play = async (track: Track) => {
+    const audio = audioRef.current;
+    if (!audio) return;
+    if (currentTrack?.id !== track.id) {
+      setCurrentTrack(track);
+      audio.src = track.audioUrl;
+    }
+    await audio.play();
+    setIsPlaying(true);
+  };
+
+  const pause = () => {
+    if (audioRef.current) {
+      audioRef.current.pause();
+      setIsPlaying(false);
+    }
+  };
+
+  const seek = (time: number) => {
+    if (audioRef.current) audioRef.current.currentTime = time;
+  };
+
+  const handlePlaybackRateChange = (rate: number) => {
+    setPlaybackRate(rate);
+    if (audioRef.current) audioRef.current.playbackRate = rate;
+  };
+
+  return (
+    <AudioContext.Provider
+      value={{
+        currentTrack,
+        isPlaying,
+        currentTime,
+        duration,
+        playbackRate,
+        play,
+        pause,
+        seek,
+        setPlaybackRate: handlePlaybackRateChange,
+      }}
+    >
+      <audio ref={audioRef} />
+      {children}
+    </AudioContext.Provider>
+  );
+}
+
+export function useAudio() {
+  const context = useContext(AudioContext);
+  if (!context) {
+    throw new Error('useAudio must be used inside AudioProvider');
+  }
+  return context;
+}

--- a/features/shared/hooks/useFavorites.ts
+++ b/features/shared/hooks/useFavorites.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+export function useFavorites() {
+  const [favoriteIds, setFavoriteIds] = useState<string[]>([]);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    const storedFavorites = localStorage.getItem('bhajanFavorites');
+    if (storedFavorites) {
+      setFavoriteIds(JSON.parse(storedFavorites));
+    }
+  }, []);
+
+  const toggleFavorite = (bhajanId: string) => {
+    const newFavoriteIds = favoriteIds.includes(bhajanId)
+      ? favoriteIds.filter((id) => id !== bhajanId)
+      : [...favoriteIds, bhajanId];
+    setFavoriteIds(newFavoriteIds);
+    localStorage.setItem('bhajanFavorites', JSON.stringify(newFavoriteIds));
+    queryClient.invalidateQueries();
+  };
+
+  const isFavorite = (bhajanId: string) => favoriteIds.includes(bhajanId);
+
+  return { favoriteIds, toggleFavorite, isFavorite };
+}

--- a/features/shared/hooks/useShareBhajan.ts
+++ b/features/shared/hooks/useShareBhajan.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export function useShareBhajan() {
+  const [copiedId, setCopiedId] = React.useState<string | null>(null);
+
+  const share = async (bhajan: { id: string; title: string; author: string }) => {
+    const url = `${window.location.origin}/bhajan/${bhajan.id}`;
+    const shareData = { title: bhajan.title, text: `${bhajan.title} — ${bhajan.author}`, url };
+
+    if (navigator.share) {
+      try {
+        await navigator.share(shareData);
+        return;
+      } catch {}
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedId(bhajan.id);
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch {
+      prompt('Скопируйте ссылку:', url);
+    }
+  };
+
+  return { share, copiedId };
+}

--- a/features/shared/hooks/useTheme.ts
+++ b/features/shared/hooks/useTheme.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export function useTheme() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const dark = stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    setIsDark(dark);
+    document.documentElement.classList.toggle('dark', dark);
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem('theme', next ? 'dark' : 'light');
+  };
+
+  return { isDark, toggle };
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,9 @@
 // File: pages/index.tsx (финальная рабочая версия с русским интерфейсом)
 
-import React, { useState, useRef, useEffect, createContext, useContext } from "react";
+import React, { useState, useEffect } from "react";
 import dynamic from 'next/dynamic';
 import { BrowserRouter as Router, Routes, Route, Link, useNavigate, useLocation, useParams } from "react-router-dom";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Search, Play, Pause, Heart, Settings, Home, SkipBack, SkipForward, Plus, Minus, Info, DollarSign, ArrowLeft, BookOpen, Music, Music4, WifiOff, Filter, X, Share2, Check, Moon, Sun } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -11,54 +11,12 @@ import { apiClient, inferRPCOutputType } from "../client/api";
 import { Popover, PopoverContent, PopoverTrigger, Button, Card, CardContent, CardHeader, CardTitle, Input, Label, Badge, Tabs, TabsContent, TabsList, TabsTrigger, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Slider } from "../components/ui";
 import { getCachedBhajans, setCachedBhajans, fetchAndCacheDictionary } from '../lib/db';
 import { Word } from "../components/Word";
+import { AudioProvider, useAudio } from "../features/audio/audio-context";
+import { useShareBhajan } from "../features/shared/hooks/useShareBhajan";
+import { useTheme } from "../features/shared/hooks/useTheme";
+import { useFavorites } from "../features/shared/hooks/useFavorites";
 
 type Bhajan = inferRPCOutputType<"listBhajans">[0];
-const AudioContext = createContext<any>(null);
-
-// SHARING
-function useShareBhajan() {
-  const [copiedId, setCopiedId] = React.useState<string | null>(null);
-
-  const share = async (bhajan: { id: string; title: string; author: string }) => {
-    const url = `${window.location.origin}/bhajan/${bhajan.id}`;
-    const shareData = { title: bhajan.title, text: `${bhajan.title} — ${bhajan.author}`, url };
-
-    if (navigator.share) {
-      try { await navigator.share(shareData); return; } catch {}
-    }
-    try {
-      await navigator.clipboard.writeText(url);
-      setCopiedId(bhajan.id);
-      setTimeout(() => setCopiedId(null), 2000);
-    } catch {
-      prompt("Скопируйте ссылку:", url);
-    }
-  };
-
-  return { share, copiedId };
-}
-
-// DARK THEME
-function useTheme() {
-  const [isDark, setIsDark] = useState(false);
-
-  useEffect(() => {
-    const stored = localStorage.getItem('theme');
-    const dark = stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    setIsDark(dark);
-    document.documentElement.classList.toggle('dark', dark);
-  }, []);
-
-  const toggle = () => {
-    const next = !isDark;
-    setIsDark(next);
-    document.documentElement.classList.toggle('dark', next);
-    localStorage.setItem('theme', next ? 'dark' : 'light');
-  };
-
-  return { isDark, toggle };
-}
-
 // CHORD TRANSPOSITION
 const SHARP_NOTES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 const FLAT_TO_SHARP: Record<string, string> = {
@@ -94,27 +52,6 @@ function CopyToast({ visible }: { visible: boolean }) {
   );
 }
 
-// ХУКИ И ПРОВАЙДЕРЫ
-const useFavorites = () => {
-    const [favoriteIds, setFavoriteIds] = useState<string[]>([]);
-    const queryClient = useQueryClient();
-    useEffect(() => { const storedFavorites = localStorage.getItem('bhajanFavorites'); if (storedFavorites) { setFavoriteIds(JSON.parse(storedFavorites)); } }, []);
-    const toggleFavorite = (bhajanId: string) => { const newFavoriteIds = favoriteIds.includes(bhajanId) ? favoriteIds.filter(id => id !== bhajanId) : [...favoriteIds, bhajanId]; setFavoriteIds(newFavoriteIds); localStorage.setItem('bhajanFavorites', JSON.stringify(newFavoriteIds)); queryClient.invalidateQueries(); };
-    const isFavorite = (bhajanId: string) => favoriteIds.includes(bhajanId);
-    return { favoriteIds, toggleFavorite, isFavorite };
-};
-
-export function AudioProvider({ children }: { children: React.ReactNode }) {
-    const audioRef = useRef<HTMLAudioElement>(null);
-    const [currentTrack, setCurrentTrack] = useState<any>(null); const [isPlaying, setIsPlaying] = useState(false); const [currentTime, setCurrentTime] = useState(0); const [duration, setDuration] = useState(0); const [playbackRate, setPlaybackRate] = useState(1);
-    useEffect(() => { const audio = audioRef.current; if (!audio) return; const updateTime = () => setCurrentTime(audio.currentTime); const updateDuration = () => setDuration(audio.duration); const handleEnded = () => setIsPlaying(false); audio.addEventListener("timeupdate", updateTime); audio.addEventListener("loadedmetadata", updateDuration); audio.addEventListener("ended", handleEnded); return () => { audio.removeEventListener("timeupdate", updateTime); audio.removeEventListener("loadedmetadata", updateDuration); audio.removeEventListener("ended", handleEnded); }; }, [currentTrack]);
-    const play = async (track: any) => { const audio = audioRef.current; if (!audio) return; if (currentTrack?.id !== track.id) { setCurrentTrack(track); audio.src = track.audioUrl; } await audio.play(); setIsPlaying(true); };
-    const pause = () => { if (audioRef.current) { audioRef.current.pause(); setIsPlaying(false); } };
-    const seek = (time: number) => { if (audioRef.current) audioRef.current.currentTime = time; };
-    const handlePlaybackRateChange = (rate: number) => { setPlaybackRate(rate); if (audioRef.current) audioRef.current.playbackRate = rate; };
-    return (<AudioContext.Provider value={{ currentTrack, isPlaying, currentTime, duration, playbackRate, play, pause, seek, setPlaybackRate: handlePlaybackRateChange }}><audio ref={audioRef} />{children}</AudioContext.Provider>);
-}
-function useAudio() { return useContext(AudioContext); }
 function formatTime(seconds: number): string { const mins = Math.floor(seconds / 60); const secs = Math.floor(seconds % 60); return `${mins}:${secs.toString().padStart(2, "0")}`; }
 
 // КОМПОНЕНТЫ


### PR DESCRIPTION
### Motivation

- Reduce complexity of the monolithic `pages/index.tsx` by extracting audio logic and common hooks into feature modules to improve maintainability and testability.
- Introduce a concrete roadmap and architecture guidance for hardening backend, dictionary sync, DB schema, and developer experience via `PROJECT_IMPROVEMENT_PLAN.md`.

### Description

- Added `features/audio/audio-context.tsx` which implements `AudioProvider` and `useAudio` to centralize audio playback state and controls such as `play`, `pause`, `seek`, and `setPlaybackRate`.
- Added shared hooks `useFavorites` (`features/shared/hooks/useFavorites.ts`), `useShareBhajan` (`features/shared/hooks/useShareBhajan.ts`), and `useTheme` (`features/shared/hooks/useTheme.ts`) and replaced the inlined implementations in `pages/index.tsx` with imports from these new modules.
- Updated `pages/index.tsx` to remove embedded providers/hooks and to consume the new `AudioProvider`, `useAudio`, `useShareBhajan`, `useTheme`, and `useFavorites` abstractions, simplifying the page file.
- Added `PROJECT_IMPROVEMENT_PLAN.md` with technical risks, a phased target architecture, DB schema suggestions (Prisma example), UX improvements, observability and CI recommendations, and a prioritized roadmap.

### Testing

- No automated tests were added or executed as part of this change; this PR focuses on refactor and documentation only and requires adding unit tests (for `useAudio`, `useFavorites`, `useTheme`, and utilities) and CI checks (`npm run lint`, `npm run typecheck`, `npm run test`) in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c72a1ca4832da81e149a90909e34)