### PR TITLE
Add OCR table extraction and two-step draft→lesson conversion with admin editor

### DIFF
--- a/pages/api/admin/convert-lesson.ts
+++ b/pages/api/admin/convert-lesson.ts
@@ -49,6 +49,63 @@ Rules:
 - Set wordBreak true at the end of visible words or phrases.
 - Keep warnings concise and useful for a human editor.`;
 
+const OCR_TABLE_PROMPT = `You are OCR stage for bhajan notation.
+
+Task: extract simplified editable table from uploaded sheet (PDF/image).
+Return ONLY valid JSON with schema:
+{
+  "title": "bhajan title",
+  "warnings": ["short Russian warnings"],
+  "rows": [
+    {
+      "part": "Часть 1.1",
+      "beat": 1,
+      "cell": "SG̲",
+      "lyric": "НАМА-",
+      "duration": 500,
+      "notes": "optional short OCR comment"
+    }
+  ]
+}
+
+Rules:
+- Preserve order by part and beat.
+- Keep raw swara text in cell exactly how OCR sees it, including underline markers _, ̲, ̱.
+- Underlined R/G/D/N and underlined M are very important; do not silently normalize them.
+- lyric should contain only printed Cyrillic lyric syllable for that cell.
+- If no lyric, set lyric to "".
+- Use duration 500 by default, 1000/1500 if the cell visibly spans 2/3 beats.
+- If uncertain about underline or accidental, add warning.`;
+
+const FROM_DRAFT_PROMPT = `You convert approved editable OCR table into final lesson JSON.
+
+Return ONLY valid JSON with schema:
+{
+  "title": "bhajan title",
+  "confidence": "high" | "medium" | "low",
+  "warnings": [],
+  "steps": [{"part":"Часть 1.1","beat":1,"swara":"S","note":"C4","lyric":"НА","duration":500,"wordBreak":false}]
+}
+
+Rules:
+- Input rows are trusted by editor.
+- Split compound swaras inside one cell into multiple steps (SG̲, PP, RG, DN, SR etc).
+- Keep lyric only on first split note, next notes with lyric "".
+- Swara mapping: S=C4,R=D4,G=E4,M=F4,P=G4,D=A4,N=B4.
+- Underlined R/G/D/N -> Db/Eb/Ab/Bb. Underlined M or M#/M+ -> Gb.
+- Lowercase r/g/d/n are komal too.
+- Keep beat order and part grouping.
+- Preserve duration from rows; split equally for compound cells.`;
+
+function extractJson(content: string) {
+  const fenced = String(content || '').match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const raw = fenced?.[1] ?? String(content || '');
+  const start = raw.indexOf('{');
+  const end = raw.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) throw new Error('No JSON object found');
+  return JSON.parse(raw.slice(start, end + 1));
+}
+
 function makeFilePart(dataUrl: string, mimeType: string, fileName: string) {
   if (mimeType.startsWith('image/')) {
     return { type: 'image_url', image_url: { url: dataUrl } };
@@ -74,9 +131,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(500).json({ error: 'OPENROUTER_API_KEY is not configured' });
   }
 
-  const { dataUrl, mimeType, fileName, bhajanTitle } = req.body ?? {};
-  if (!dataUrl || !mimeType || !fileName) {
-    return res.status(400).json({ error: 'dataUrl, mimeType and fileName are required' });
+  const { dataUrl, mimeType, fileName, bhajanTitle, mode = 'ocr', ocrDraft } = req.body ?? {};
+  if (mode === 'ocr' && (!dataUrl || !mimeType || !fileName)) {
+    return res.status(400).json({ error: 'dataUrl, mimeType and fileName are required for OCR mode' });
+  }
+  if (mode === 'from-draft' && !ocrDraft) {
+    return res.status(400).json({ error: 'ocrDraft is required for from-draft mode' });
   }
 
   try {
@@ -89,14 +149,18 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         'X-Title': 'BhajanApp Lesson Converter',
       },
       body: JSON.stringify({
-        model: 'google/gemini-2.5-flash',
+        model: mode === 'ocr' ? 'baidu/qianfan-ocr-fast:free' : 'google/gemini-2.5-flash',
         messages: [
           {
             role: 'user',
-            content: [
-              { type: 'text', text: `${CONVERTER_PROMPT}\n\nSelected bhajan: ${bhajanTitle || 'unknown'}` },
-              makeFilePart(dataUrl, mimeType, fileName),
-            ],
+            content: mode === 'ocr'
+              ? [
+                { type: 'text', text: `${OCR_TABLE_PROMPT}\n\nSelected bhajan: ${bhajanTitle || 'unknown'}` },
+                makeFilePart(dataUrl, mimeType, fileName),
+              ]
+              : [
+                { type: 'text', text: `${FROM_DRAFT_PROMPT}\n\nSelected bhajan: ${bhajanTitle || 'unknown'}\n\nOCR draft:\n${JSON.stringify(ocrDraft)}` },
+              ],
           },
         ],
         temperature: 0.1,
@@ -113,7 +177,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(502).json({ error: 'Empty response from converter model' });
     }
 
-    const lesson = parseLessonFromModelResponse(content, bhajanTitle || fileName);
+    if (mode === 'ocr') {
+      const draft = extractJson(content);
+      return res.status(200).json({ draft });
+    }
+
+    const lesson = parseLessonFromModelResponse(content, bhajanTitle || fileName || 'Bhajan lesson');
     return res.status(200).json({ lesson });
   } catch (error: any) {
     return res.status(500).json({ error: error?.message ?? 'Lesson conversion failed' });

--- a/pages/artartemev_admin.tsx
+++ b/pages/artartemev_admin.tsx
@@ -9,6 +9,7 @@ type LogEntry = { word: string; result: string; ok: boolean };
 
 type Phase = 'idle' | 'collecting' | 'translating' | 'done';
 type BhajanOption = { id: string; title: string; author: string };
+const NOTE_OPTIONS = ['', 'C3', 'Db3', 'D3', 'Eb3', 'E3', 'F3', 'Gb3', 'G3', 'Ab3', 'A3', 'Bb3', 'B3', 'C4', 'Db4', 'D4', 'Eb4', 'E4', 'F4', 'Gb4', 'G4', 'Ab4', 'A4', 'Bb4', 'B4', 'C5', 'Db5', 'D5', 'Eb5', 'E5', 'F5', 'Gb5', 'G5', 'Ab5', 'A5', 'Bb5', 'B5'];
 
 function readFileAsDataUrl(file: File) {
   return new Promise<string>((resolve, reject) => {
@@ -42,9 +43,11 @@ export default function AdminPage() {
   const [lessonFile, setLessonFile] = useState<File | null>(null);
   const [lesson, setLesson] = useState<LessonData | null>(null);
   const [lessonText, setLessonText] = useState('');
+  const [ocrDraftText, setOcrDraftText] = useState('');
   const [lessonStatus, setLessonStatus] = useState('');
   const [isConvertingLesson, setIsConvertingLesson] = useState(false);
   const [isSavingLesson, setIsSavingLesson] = useState(false);
+  const [selectedStepIndex, setSelectedStepIndex] = useState<number>(0);
 
   useEffect(() => {
     apiClient.listBhajans({})
@@ -68,13 +71,14 @@ export default function AdminPage() {
     }
 
     setIsConvertingLesson(true);
-    setLessonStatus('Конвертируем схему в урок...');
+    setLessonStatus('OCR: распознаём схему в черновую таблицу...');
     try {
       const dataUrl = await readFileAsDataUrl(lessonFile);
       const resp = await fetch('/api/admin/convert-lesson', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          mode: 'ocr',
           bhajanId: selectedBhajan.id,
           bhajanTitle: selectedBhajan.title,
           bhajanAuthor: selectedBhajan.author,
@@ -85,11 +89,45 @@ export default function AdminPage() {
       });
       const data = await resp.json();
       if (!resp.ok) throw new Error(data.error ?? 'Ошибка конвертации');
+      setOcrDraftText(JSON.stringify(data.draft, null, 2));
+      setLesson(null);
+      setLessonText('');
+      setLessonStatus('OCR готов. Проверьте/исправьте таблицу и нажмите «Собрать lesson JSON из таблицы».');
+    } catch (error: any) {
+      setLessonStatus(error?.message ?? 'Ошибка конвертации');
+    } finally {
+      setIsConvertingLesson(false);
+    }
+  }
+
+  async function buildLessonFromDraft() {
+    if (!selectedBhajan || !ocrDraftText.trim()) {
+      setLessonStatus('Сначала выполните OCR и получите черновую таблицу.');
+      return;
+    }
+
+    setIsConvertingLesson(true);
+    setLessonStatus('Собираем финальный lesson JSON из утверждённой таблицы...');
+    try {
+      const draft = JSON.parse(ocrDraftText);
+      const resp = await fetch('/api/admin/convert-lesson', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'from-draft',
+          bhajanId: selectedBhajan.id,
+          bhajanTitle: selectedBhajan.title,
+          bhajanAuthor: selectedBhajan.author,
+          ocrDraft: draft,
+        }),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.error ?? 'Ошибка сборки lesson JSON');
       setLesson(data.lesson);
       setLessonText(JSON.stringify(data.lesson, null, 2));
       setLessonStatus(`Готово: ${data.lesson.steps.length} шагов. Проверьте предпросмотр перед сохранением.`);
     } catch (error: any) {
-      setLessonStatus(error?.message ?? 'Ошибка конвертации');
+      setLessonStatus(error?.message ?? 'Ошибка сборки lesson JSON');
     } finally {
       setIsConvertingLesson(false);
     }
@@ -105,6 +143,16 @@ export default function AdminPage() {
     } catch (error: any) {
       setLessonStatus(error?.message ?? 'JSON содержит ошибку');
     }
+  }
+
+  function updateLessonStep(index: number, patch: Partial<LessonData['steps'][number]>) {
+    setLesson(prev => {
+      if (!prev || !prev.steps[index]) return prev;
+      const nextSteps = prev.steps.map((step, i) => i === index ? { ...step, ...patch } : step);
+      const nextLesson = { ...prev, steps: nextSteps };
+      setLessonText(JSON.stringify(nextLesson, null, 2));
+      return nextLesson;
+    });
   }
 
   async function loadLessonJsonFile(file: File | null) {
@@ -292,7 +340,18 @@ export default function AdminPage() {
                 opacity: isConvertingLesson || !lessonFile || !selectedBhajan ? 0.55 : 1,
               }}
             >
-              {isConvertingLesson ? 'Конвертируем...' : 'Сконвертировать'}
+              {isConvertingLesson ? 'OCR...' : '1) Сделать OCR таблицу'}
+            </button>
+            <button
+              onClick={buildLessonFromDraft}
+              disabled={isConvertingLesson || !ocrDraftText.trim() || !selectedBhajan}
+              style={{
+                background: '#0f766e', color: '#fff', border: 'none', borderRadius: 8,
+                padding: '10px 18px', fontSize: 15, cursor: 'pointer', fontWeight: 600,
+                opacity: isConvertingLesson || !ocrDraftText.trim() || !selectedBhajan ? 0.55 : 1,
+              }}
+            >
+              2) Собрать lesson JSON из таблицы
             </button>
             <button
               onClick={applyLessonJson}
@@ -324,7 +383,76 @@ export default function AdminPage() {
             <div>
               <h3 style={{ fontSize: 15, fontWeight: 600, marginBottom: 8 }}>Предпросмотр</h3>
               {lesson ? (
-                <LessonPlayer lesson={lesson} compact />
+                <div style={{ display: 'grid', gap: 12 }}>
+                  <LessonPlayer lesson={lesson} compact />
+                  <div style={{ border: '1px solid #ddd', borderRadius: 8, padding: 12, background: '#fff' }}>
+                    <h4 style={{ margin: '0 0 8px', fontSize: 14 }}>Интерактивный редактор нот по слогам</h4>
+                    <p style={{ margin: '0 0 10px', color: '#666', fontSize: 12 }}>
+                      Кликните на слог/паузу ниже, затем измените swara, note и duration справа.
+                    </p>
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginBottom: 12 }}>
+                      {lesson.steps.map((step, index) => (
+                        <button
+                          key={`${step.part ?? 'p'}-${index}`}
+                          onClick={() => setSelectedStepIndex(index)}
+                          style={{
+                            border: index === selectedStepIndex ? '1px solid #0f766e' : '1px solid #ddd',
+                            borderRadius: 999,
+                            background: index === selectedStepIndex ? '#ccfbf1' : '#fff',
+                            padding: '4px 10px',
+                            fontSize: 12,
+                            cursor: 'pointer',
+                          }}
+                        >
+                          {step.lyric || '•'} · {step.swara || '-'}
+                        </button>
+                      ))}
+                    </div>
+
+                    {lesson.steps[selectedStepIndex] && (
+                      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, minmax(0, 1fr))', gap: 8 }}>
+                        <label style={{ display: 'grid', gap: 4, fontSize: 12 }}>
+                          Слог
+                          <input
+                            value={lesson.steps[selectedStepIndex].lyric || ''}
+                            onChange={e => updateLessonStep(selectedStepIndex, { lyric: e.target.value })}
+                            style={{ border: '1px solid #ddd', borderRadius: 6, padding: 8 }}
+                          />
+                        </label>
+                        <label style={{ display: 'grid', gap: 4, fontSize: 12 }}>
+                          Swara
+                          <input
+                            value={lesson.steps[selectedStepIndex].swara || ''}
+                            onChange={e => updateLessonStep(selectedStepIndex, { swara: e.target.value })}
+                            style={{ border: '1px solid #ddd', borderRadius: 6, padding: 8 }}
+                          />
+                        </label>
+                        <label style={{ display: 'grid', gap: 4, fontSize: 12 }}>
+                          Note
+                          <select
+                            value={lesson.steps[selectedStepIndex].note || ''}
+                            onChange={e => updateLessonStep(selectedStepIndex, { note: e.target.value || null })}
+                            style={{ border: '1px solid #ddd', borderRadius: 6, padding: 8 }}
+                          >
+                            <option value="">(пауза)</option>
+                            {NOTE_OPTIONS.filter(Boolean).map(note => <option key={note} value={note}>{note}</option>)}
+                          </select>
+                        </label>
+                        <label style={{ display: 'grid', gap: 4, fontSize: 12 }}>
+                          Duration (ms)
+                          <input
+                            type="number"
+                            min={80}
+                            max={4000}
+                            value={lesson.steps[selectedStepIndex].duration}
+                            onChange={e => updateLessonStep(selectedStepIndex, { duration: Math.max(80, Number(e.target.value) || 500) })}
+                            style={{ border: '1px solid #ddd', borderRadius: 6, padding: 8 }}
+                          />
+                        </label>
+                      </div>
+                    )}
+                  </div>
+                </div>
               ) : (
                 <div style={{ border: '1px dashed #ddd', borderRadius: 8, minHeight: 220, display: 'grid', placeItems: 'center', color: '#888', padding: 24, textAlign: 'center' }}>
                   Сконвертируйте схему или вставьте JSON, чтобы увидеть урок.
@@ -346,6 +474,13 @@ export default function AdminPage() {
                 onChange={event => setLessonText(event.target.value)}
                 placeholder="Вставьте сюда JSON от внешней LLM и нажмите «Предпросмотр из JSON»."
                 style={{ width: '100%', minHeight: 420, border: '1px solid #ddd', borderRadius: 8, padding: 12, fontFamily: 'monospace', fontSize: 12 }}
+              />
+              <h3 style={{ fontSize: 15, fontWeight: 600, margin: '12px 0 8px' }}>OCR черновая таблица (редактируемая)</h3>
+              <textarea
+                value={ocrDraftText}
+                onChange={event => setOcrDraftText(event.target.value)}
+                placeholder="После OCR здесь появится упрощённая таблица rows. Исправьте подчёркнутые ноты и затем нажмите «Собрать lesson JSON из таблицы»."
+                style={{ width: '100%', minHeight: 220, border: '1px solid #ddd', borderRadius: 8, padding: 12, fontFamily: 'monospace', fontSize: 12 }}
               />
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Enable a two-step workflow where an OCR model extracts an editable table from scanned bhajan sheets and an editor-approved draft is converted into the final lesson JSON.
- Provide a safer editing surface for OCR uncertainties (underlines/accidentals) and let human editors correct the draft before final parsing.
- Give admins quick in-UI editing of individual lesson steps (swara/note/duration/lyric) for faster corrections.

### Description
- API: extended `pages/api/admin/convert-lesson.ts` to support two modes: `mode: 'ocr'` (calls `baidu/qianfan-ocr-fast:free` and returns a parsed draft JSON) and `mode: 'from-draft'` (calls `google/gemini-2.5-flash` to convert an approved OCR draft into the final lesson JSON), added `OCR_TABLE_PROMPT` and `FROM_DRAFT_PROMPT`, and added `extractJson` to robustly pull JSON from model responses.
- API: improved input validation and response handling for both modes and preserved existing parsing path for final lesson creation via `parseLessonFromModelResponse`.
- Admin UI: updated `pages/artartemev_admin.tsx` to add OCR workflow UI: file->OCR button produces editable `ocrDraftText`, a second button sends the draft back to the API for final conversion, and a textarea shows the editable OCR table.
- Admin UI: added an inline interactive per-step editor (select step, edit `lyric`, `swara`, `note`, `duration`) and `updateLessonStep` helper, plus `NOTE_OPTIONS` list and minor status/message copy changes.

### Testing
- Performed TypeScript type-check and local Next.js build (`tsc --noEmit` and `next build`) to ensure compilation succeeded.
- Manually exercised the two-step flow in a local dev server: uploaded file → received OCR draft JSON → edited draft → built final lesson JSON, and the preview/editor updated as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5bfbf6a70832d99f27d83a77a2f75)